### PR TITLE
Handle file descriptor 0 (stdin) correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function dump() {
         if (h instanceof Socket) {
             // stdin, stdout, etc. are now instances of socket and get listed in open handles
             // todo: a more specific/better way to identify them than the 'fd' property
-            if (h.fd) { fds.push(h); }
+            if (h.fd !== null) { fds.push(h); }
             else { sockets.push(h); }
         }
         else if (h instanceof Server) { servers.push(h); }

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function dump() {
         if (h instanceof Socket) {
             // stdin, stdout, etc. are now instances of socket and get listed in open handles
             // todo: a more specific/better way to identify them than the 'fd' property
-            if (h.fd !== null) { fds.push(h); }
+            if (h.hasOwnProperty('fd')) { fds.push(h); }
             else { sockets.push(h); }
         }
         else if (h instanceof Server) { servers.push(h); }


### PR DESCRIPTION
I was seeing fd 0 show up as an "Unknown socket" because 0 is falsey and therefore h.fd was falsey.