### PR TITLE
Fix findCallSite for windows and null cp.stdio elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
 'use strict';
-var path = require('path');
-
-var Socket, dgramSocket, Server, TlsServer, HttpServer, HttpsServer, Timer, ChildProcess;
+// Don't require these until we've hooked certain builtins
+var ChildProcess,
+    dgramSocket,
+    HttpServer,
+    HttpsServer,
+    path,
+    Server,
+    Socket,
+    Timer,
+    TlsServer;
 
 function timerCallback(thing) {
     if (typeof thing._repeat === 'function') { return '_repeat'; }
@@ -134,13 +141,18 @@ function timerCallback(thing) {
     };
 })();
 
-Socket = require('net').Socket;
-Server = require('net').Server;
-TlsServer = require('tls').Server;
+// path must be required before the rest of these
+// as some of them invoke our hooks on load which
+// requires path to be available to the above code
+path = require('path');
+
+dgramSocket = require('dgram').Socket;
 HttpServer = require('http').Server;
 HttpsServer = require('https').Server;
+Server = require('net').Server;
+Socket = require('net').Socket;
 Timer = process.binding('timer_wrap').Timer;
-dgramSocket = require('dgram').Socket;
+TlsServer = require('tls').Server;
 
 ChildProcess = (function () {
     var ChildProcess = require('child_process').ChildProcess;

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ function dump() {
         if (h instanceof Socket) {
             // stdin, stdout, etc. are now instances of socket and get listed in open handles
             // todo: a more specific/better way to identify them than the 'fd' property
-            if (h.hasOwnProperty('fd')) { fds.push(h); }
+            if ((h.fd != null)) { fds.push(h); }
             else { sockets.push(h); }
         }
         else if (h instanceof Server) { servers.push(h); }

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function dump() {
             console.log('  - PID %s', cp.pid);
             if (cp.stdio && cp.stdio.length) {
                 cp.stdio.forEach(function (s) {
-                    if (s && s._handle && s._handle.fd) { fds.push(s._handle.fd); }
+                    if (s && s._handle && (s._handle.fd != null)) { fds.push(s._handle.fd); }
                     var idx = sockets.indexOf(s);
                     if (idx > -1) {
                         sockets.splice(idx, 1);
@@ -238,7 +238,7 @@ function dump() {
                 console.log('  - (?:?) -> %s:? (destroyed)', s._host);
             } else if (s.localAddress) {
                 console.log('  - %s:%s -> %s:%s', s.localAddress, s.localPort, s.remoteAddress, s.remotePort);
-            } else if (s._handle && s._handle.fd) {
+            } else if (s._handle && (s._handle.fd != null)) {
                 console.log('  - fd %s', s._handle.fd);
             } else {
                 console.log('  - unknown socket');

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function dump() {
         if (h instanceof Socket) {
             // stdin, stdout, etc. are now instances of socket and get listed in open handles
             // todo: a more specific/better way to identify them than the 'fd' property
-            if (h.fd) { fds.push(h); }
+            if (h.fd !== null) { fds.push(h); }
             else { sockets.push(h); }
         }
         else if (h instanceof Server) { servers.push(h); }

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function dump() {
         if (h instanceof Socket) {
             // stdin, stdout, etc. are now instances of socket and get listed in open handles
             // todo: a more specific/better way to identify them than the 'fd' property
-            if (h.fd !== null) { fds.push(h); }
+            if (h.hasOwnProperty('fd')) { fds.push(h); }
             else { sockets.push(h); }
         }
         else if (h instanceof Server) { servers.push(h); }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 'use strict';
+var path = require('path');
 
 var Socket, dgramSocket, Server, TlsServer, HttpServer, HttpsServer, Timer, ChildProcess;
 
@@ -32,7 +33,10 @@ function timerCallback(thing) {
 
     function findCallsite(stack) {
         for (var i = 0; i < stack.length; i++) {
-            if (stack[i].file !== __filename && /\//.test(stack[i].file)) {
+            // Ignore frames from:
+            //  - wtfnode by excluding __filename
+            //  - builtins by excluding files with no path separator
+            if (stack[i].file !== __filename && stack[i].file.indexOf(path.sep) !== -1) {
               return stack[i];
             }
         }
@@ -90,7 +94,6 @@ function timerCallback(thing) {
                 value: isInterval
             }
         });
-
         return wrapped;
     }
 
@@ -215,10 +218,9 @@ function dump() {
         processes.forEach(function (cp) {
             var fds = [ ];
             console.log('  - PID %s', cp.pid);
-            
             if (cp.stdio && cp.stdio.length) {
                 cp.stdio.forEach(function (s) {
-                    if (s._handle && s._handle.fd) { fds.push(s._handle.fd); }
+                    if (s && s._handle && s._handle.fd) { fds.push(s._handle.fd); }
                     var idx = sockets.indexOf(s);
                     if (idx > -1) {
                         sockets.splice(idx, 1);


### PR DESCRIPTION
On windows, callsite logging wasn't working for me as none of the filepaths matched the regex.
Also in the kitchensink test cp.stdio looked like `[null, null, null]`. This may be an old node thing (i'm on 0.12.4), so i added a check for that.