### PR TITLE
Support command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You'll see that the function name listed under timers is `wrapper` -- this is th
 
 You can install as a global module (`npm install -g wtfnode`) and call a node script manually: `wtfnode <yourscript>`
 
-If you do this, `wtfnode` will load itself, then `require()` the script you specified. When you are ready, send SIGINT (Ctrl+C). The process will exit, and the active handles at the time of exit will be printed out.
+If you do this, `wtfnode` will load itself, then forward control to the script you specified as if you had run `node <yourscript>`. When you are ready, send SIGINT (Ctrl+C). The process will exit, and the active handles at the time of exit will be printed out.
+
+You can tunnel parameters to your script by preceding them with a `--` delimiter: `wtfnode <yourscript> -- <yourargs> ...`
 
 # Module usage
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ You'll see that the function name listed under timers is `wrapper` -- this is th
 
 # Command line usage
 
-You can install as a global module (`npm install -g wtfnode`) and call a node script manually: `wtfnode <yourscript>`
+You can install as a global module (`npm install -g wtfnode`) and call a node script manually: `wtfnode <yourscript> <yourargs> ...`
 
-If you do this, `wtfnode` will load itself, then forward control to the script you specified as if you had run `node <yourscript>`. When you are ready, send SIGINT (Ctrl+C). The process will exit, and the active handles at the time of exit will be printed out.
-
-You can tunnel parameters to your script by preceding them with a `--` delimiter: `wtfnode <yourscript> -- <yourargs> ...`
+If you do this, `wtfnode` will load itself, then forward control to the script you specified as if you had run `node <yourscript> ...`. When you are ready, send SIGINT (Ctrl+C). The process will exit, and the active handles at the time of exit will be printed out.
 
 # Module usage
 

--- a/index.js
+++ b/index.js
@@ -398,14 +398,27 @@ module.exports = {
     init: init
 };
 
-if (module === require.main && process.argv[2]) {
-    init();
-    
-    var fn = process.argv[2], PATH = require('path');
-    if (!/^\//.test(fn)) {
-        fn = PATH.resolve(process.cwd(), fn);
+function parseArgs() {
+    if (process.argv.length < 3) {
+        throw new Error('Usage: wtfnode <yourscript> -- <yourargs> ...');
     }
-    
-    var ret = require(fn);
-    if (typeof ret === 'function') { ret(); }
+    var moduleParams = [];
+    var delimIndex = process.argv.indexOf('--');
+    if (delimIndex !== -1) {
+        moduleParams = process.argv.slice(delimIndex + 1);
+    }
+    var modulePath = path.resolve(process.cwd(), process.argv[2]);
+    return [].concat(process.argv[0], modulePath, moduleParams);
+}
+
+if (module === require.main) {
+    init();
+    // The goal here is to invoke the given module in a form that is as
+    // identical as possible to invoking `node <the_module>` directly.
+    // This means massaging process.argv and using Module.runMain to convince
+    // the module that it is the 'main' module.
+    var newArgv = parseArgs(process.argv)
+    var Module = require('module');
+    process.argv = newArgv;
+    Module.runMain();
 }

--- a/index.js
+++ b/index.js
@@ -400,13 +400,10 @@ module.exports = {
 
 function parseArgs() {
     if (process.argv.length < 3) {
-        throw new Error('Usage: wtfnode <yourscript> -- <yourargs> ...');
+        console.error('Usage: wtfnode <yourscript> <yourargs> ...');
+        process.exit(1);
     }
-    var moduleParams = [];
-    var delimIndex = process.argv.indexOf('--');
-    if (delimIndex !== -1) {
-        moduleParams = process.argv.slice(delimIndex + 1);
-    }
+    var moduleParams = process.argv.slice(3);
     var modulePath = path.resolve(process.cwd(), process.argv[2]);
     return [].concat(process.argv[0], modulePath, moduleParams);
 }


### PR DESCRIPTION
Add's support for tunneling command line args to the target script. Also makes the target script launch like it was invoked by `node <targetScript>`.

This builds on top of PR https://github.com/myndzi/wtfnode/pull/5, only this commit https://github.com/myndzi/wtfnode/commit/87f24a44997e0b2271c99e34f740567991674ad9 is necessary to review.