### PR TITLE
Fix EventEmitter.removeListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,14 @@ function timerCallback(thing) {
             return fn.apply(this, arguments);
         };
 
+        // This is intended to interact "cleverly" with node's EventEmitter logic.
+        // EventEmitter itself sometimes wraps the event handler callbacks to implement
+        // things such as once(). See https://github.com/nodejs/node/blob/v6.0.0/lib/events.js#L280
+        // In order for removeListener to still work when called with the original unwrapped function
+        // a .listener member is added to the stored callback which contains the original unwrapped function
+        // and the removeListener logic checks this member as well to match wrapped listeners.
+        wrapped.listener = fn;
+
         var stack = __stack;
 
         // this should inherit 'name' and 'length' and any other properties that have been assigned

--- a/kitchensink.js
+++ b/kitchensink.js
@@ -1,13 +1,15 @@
 var wtf = require('./index');
 
-var fs = require('fs'),
+var assert = require('assert');
     cp = require('child_process'),
-    net = require('net'),
-    tls = require('tls'),
+    dgram = require('dgram'),
+    EventEmitter = require('events'),
+    fs = require('fs'),
     http = require('http'),
     https = require('https'),
-    dgram = require('dgram'),
-    readline = require('readline');
+    net = require('net'),
+    readline = require('readline'),
+    tls = require('tls');
 
 function foo() { };
 
@@ -48,6 +50,23 @@ function doStuff() {
   console.error('Argv[2..]:', process.argv.slice(2));
   process.exit();
 }
+
+function testEventEmitter() {
+  var emitter = new EventEmitter();
+  var numTimesEventHandlerWasCalled = 0;
+  var myEventHandler = function() {
+    numTimesEventHandlerWasCalled += 1;
+  };
+  emitter.addListener('myEvent', myEventHandler);
+  emitter.emit('myEvent');
+  assert(numTimesEventHandlerWasCalled === 1);
+  // Check that removeListener still works:
+  emitter.removeListener('myEvent', myEventHandler);
+  emitter.emit('myEvent');
+  assert(numTimesEventHandlerWasCalled === 1);
+}
+
+testEventEmitter();
 
 // child processes
 var proc = cp.spawn('cat');


### PR DESCRIPTION
When running wtfnode on a meatier system than last time, I noticed that EventEmitter.removeListener wasn't working because of function wrapping. I had an issue with websocket upgrades in node's http module, but I'd imagine this affects a lot of functionality.

I added a small check to kitchensink.js which validates the fix (it fails without it).

The fix is a glorious hack in its own right.

I've only tested on node v0.12.4, but the EventEmitter logic it's based on seems to be the same up to latest (v6.x).