### PR TITLE
Add support for node 0.10.32

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ ChildProcess = (function () {
 
     if (typeof ChildProcess !== 'function') {
         // node 0.10 doesn't expose the ChildProcess constructor, so we have to get it on the sly
-        var cp = require('child_process').spawn('true', { stdio: 'ignore' });
+        var cp = require('child_process').spawn('true', [], { stdio: 'ignore' });
         ChildProcess = cp.constructor;
     }
 


### PR DESCRIPTION
The interface for spawn in node 0.10.32 requires an array as the second argument to spawn. This change has been tested with 0.10.32 and 0.10.36, and conforms to the interface of spawn for all 0.10 patches of node.