### PR TITLE
help identify open http client sockets

### DIFF
--- a/index.js
+++ b/index.js
@@ -560,6 +560,9 @@ function dump() {
             } else {
                 log('info', '  - unknown socket');
             }
+            if(s._httpMessage) {
+                log('info', '    - %s %s//%s%s', s._httpMessage.method, s._httpMessage.protocol, s._httpMessage.host, s._httpMessage.path);
+            }
             var connectListeners = s.listeners('connect');
             if (connectListeners && connectListeners.length) {
                 log('info', '    - Listeners:');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "test": "(cd tests && node test && node test-eval && node test-promise && node test-promisify && node test-logging && node test-once-flowing && node test-issue-37.js && node test-no-source-map-support && node test-broken-source-map-support)",
+    "test": "(cd tests && node test && node test-eval && node test-promise && node test-promisify && node test-logging && node test-once-flowing && node test-issue-37.js && node test-no-source-map-support && node test-broken-source-map-support && node test-http-client)",
     "test-sourcemaps": "(cd tests && coffee --map --compile test-sourcemaps.coffee && node test-sourcemaps.js || exit 0)",
     "kitchensink": "(cd tests && node kitchensink)"
   },

--- a/tests/test-http-client.js
+++ b/tests/test-http-client.js
@@ -1,0 +1,30 @@
+"use strict";
+var wtf = require("../index");
+var http = require("http");
+
+var logs = [];
+
+wtf.setLogger("info", function (log) {
+  logs.push(log);
+});
+
+var server = http.createServer((req, res) => {
+  res.writeHead(200);
+  res.end();
+});
+
+server.listen(0, function () {
+  var port = server.address().port;
+  http.get({ method: "POST", host: "localhost", port, path: "/the-path" }, function () {
+    wtf.dump();
+    if (
+      logs.some(function (l) {
+        return l === "    - POST http://localhost/the-path";
+      })
+    ) {
+      process.exit(0);
+    } else {
+      throw new Error("Expected detailed http log");
+    }
+  });
+});


### PR DESCRIPTION
If a socket is an http client, print some extra details to help identify it.

Looks like this:
```
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
- Sockets:
  - ::1:51817 -> ::1:51816
    - POST http://localhost/the-path <--------- the new stuff
  - ::1:51816 -> ::1:51817
- Servers:
  - :::51816 (HTTP)
    - Listeners:
      - request: (anonymous) @ /Users/matt/code/wtfnode/tests/test-http-client.js:11
```