### PR TITLE
Issue 50: Cannot read properties of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,7 +564,7 @@ function dump() {
                 var req = s._httpMessage || {};
                 var agent = req.agent || {};
                 var method = req.method || 'unknown';
-                var host = req.host || req.getHeader('host').replace(/:\d+$/, '');
+                var host = req.host || (req.getHeader('host') || '').replace(/:\d+$/, '');
                 var path = req.path || 'unknown';
                 var protocol = req.protocol || agent.protocol || (function () {
                     var ctor = s.constructor && s.constructor.name;


### PR DESCRIPTION
Handle the case that a request has neither req.host nor req.getHeader('host').

I have encountered a case where the request wtfnode is trying to log has neither, causing a TypeError. This change prevents the error.

Fixes #50